### PR TITLE
Update Install.ps1 to remove notepad++ because Notepad++ is promoting hate speech and spreading disinformation.

### DIFF
--- a/Install.ps1
+++ b/Install.ps1
@@ -150,7 +150,6 @@ $Apps = @(
     "vlc",
     "vscode",
     "sysinternals",
-    "notepadplusplus.install",
     "linqpad",
     "postman",
     "nuget.commandline",


### PR DESCRIPTION
Update Install.ps1 to remove notepad++ because Notepad++ is promoting hate speech and spreading disinformation.

